### PR TITLE
Support for Quote-less urls in CSS

### DIFF
--- a/tasks/relative_root.js
+++ b/tasks/relative_root.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     }
 
     function relativizeCSS (source, relativeRoot) {
-      return source.replace(/(url\(['"])\/(?!\/)/g, "$1"+relativeRoot);
+      return source.replace(/(url\(['"]?)\/(?!\/)/g, "$1"+relativeRoot);
     }
 
     function relativizeHTML (source, relativeRoot) {


### PR DESCRIPTION
Hi there,
  I really like your task here, i was going to have to write a similar one; but had the good graces to find your project :+1: 

I have a particular project which i use grunt-contrib-cssmin, which uses cleancss; in the course of the minification process css urls are stripped of their quotes, I'm assuming to save space.

It is valid syntax for css urls to have no quotes:
  http://www.w3.org/TR/CSS2/syndata.html#uri

I'd like to purpose this fix to be able to catch such urls, allowing for quote-less urls in css. I've already tested this on my branch.

Thanks in advance for the review,
Cody
