### PR TITLE
Fix separator issue on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
   "scripts": {
     "test": "grunt test"
   },
+  "dependencies": {
+    "slash": "~0.1.3"
+  },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-clean": "~0.5.0",

--- a/tasks/relative_root.js
+++ b/tasks/relative_root.js
@@ -9,7 +9,8 @@
 'use strict';
 
 var pkg = require('../package.json'),
-    path = require('path');
+    path = require('path'),
+    slash = require('slash');
 
 module.exports = function(grunt) {
 
@@ -17,7 +18,7 @@ module.exports = function(grunt) {
     var root = this.options({root: '.'}).root;
 
     function compute (from, to) {
-      return (path.relative(path.dirname(from), to) || '.') + '/';
+      return (slash(path.relative(path.dirname(from), to)) || '.') + '/';
     }
 
     function relativizeCSS (source, relativeRoot) {


### PR DESCRIPTION
The following test fails on Windows because `path.relative()` returns a string with `"\\"` separator.

```
Testing relative_root.test.jsF.
>> relativeRoot - simple
>> Message: relativizes absolute paths in CSS
>> Error: 'body {\n  background-image: url(\'..\\../images/bg.png\');\n}' == 'body {\n  background-image: url(\'../../images/bg.png\');\n}'
>> at Object.exports.relativeRoot.simple (test\relative_root.test.js:34:10)
>> at Object.exports.relativeRoot.setUp (test\relative_root.test.js:28:5)
```

I fixed the separator issue using [slash](https://www.npmjs.org/package/slash).
Thanks for providing this useful plugin!
