### PR TITLE
Support for 2 types of paths in HTML files: CSS URL and polymer assetpath

### DIFF
--- a/tasks/relative_root.js
+++ b/tasks/relative_root.js
@@ -28,7 +28,9 @@ module.exports = function(grunt) {
     function relativizeHTML (source, relativeRoot) {
       return source
         .replace(/(href=["'])\/(?!\/)/g, '$1'+relativeRoot)
-        .replace(/(src=["'])\/(?!\/)/g, '$1'+relativeRoot);
+        .replace(/(src=["'])\/(?!\/)/g, '$1'+relativeRoot)
+        .replace(/(assetpath=["'])\/(?!\/)/g, '$1'+relativeRoot)
+        .replace(/(url\(['"]?)\/(?!\/)/g, "$1"+relativeRoot);
     }
 
     this.files.forEach(function(file) {

--- a/tasks/relative_root.js
+++ b/tasks/relative_root.js
@@ -30,6 +30,7 @@ module.exports = function(grunt) {
         .replace(/(href=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(src=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(assetpath=["'])\/(?!\/)/g, '$1'+relativeRoot)
+        .replace(/(url=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(url\(['"]?)\/(?!\/)/g, "$1"+relativeRoot);
     }
 

--- a/test/expected/fancy/prudent.html
+++ b/test/expected/fancy/prudent.html
@@ -2,9 +2,20 @@
 <html>
 <head>
   <script src="//cdn.example.com"></script>
+  <style>
+    .rectangle-resize {
+        background:url("./images/jquery-ui-icons.png") -20px -100px!important;
+        width:12px!important;
+        height:12px!important
+    }
+  </style>
 </head>
 <body>
   <img src="./images/logo.png" />
   <a href="./about">About</a>
+  <polymer-element name="core-media-query" attributes="query queryMatches" assetpath="./bower_components/core-media-query/">
+    <template><style> :host { display: none; } </style></template>
+    <script><!-- code --></script>
+  </polymer-element>
 </body>
 </html>

--- a/test/fixtures/prudent.html
+++ b/test/fixtures/prudent.html
@@ -2,9 +2,20 @@
 <html>
 <head>
   <script src="//cdn.example.com"></script>
+  <style>
+    .rectangle-resize {
+        background:url("/images/jquery-ui-icons.png") -20px -100px!important;
+        width:12px!important;
+        height:12px!important
+    }
+  </style>
 </head>
 <body>
   <img src="/images/logo.png" />
   <a href="/about">About</a>
+  <polymer-element name="core-media-query" attributes="query queryMatches" assetpath="/bower_components/core-media-query/">
+    <template><style> :host { display: none; } </style></template>
+    <script><!-- code --></script>
+  </polymer-element>
 </body>
 </html>


### PR DESCRIPTION
Hi,

For my application, I found a need to use `grunt-relative-root`, but there were two types of paths in .html not handled.  I added them and updated the `prudent.html` test case with the two examples.

A more general solution might to be allow user's to define these cases via the Gruntfile.js init settings.

Best,
Owen
