### PR TITLE
Add replacing for poster attribute

### DIFF
--- a/tasks/relative_root.js
+++ b/tasks/relative_root.js
@@ -28,6 +28,7 @@ module.exports = function(grunt) {
     function relativizeHTML (source, relativeRoot) {
       return source
         .replace(/(href=["'])\/(?!\/)/g, '$1'+relativeRoot)
+        .replace(/(poster=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(src=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(assetpath=["'])\/(?!\/)/g, '$1'+relativeRoot)
         .replace(/(url=["'])\/(?!\/)/g, '$1'+relativeRoot)

--- a/test/expected/fancy/prudent.html
+++ b/test/expected/fancy/prudent.html
@@ -17,5 +17,6 @@
     <template><style> :host { display: none; } </style></template>
     <script><!-- code --></script>
   </polymer-element>
+  <video poster='./images/poster.png'></video>
 </body>
 </html>

--- a/test/fixtures/prudent.html
+++ b/test/fixtures/prudent.html
@@ -17,5 +17,6 @@
     <template><style> :host { display: none; } </style></template>
     <script><!-- code --></script>
   </polymer-element>
+  <video poster='/images/poster.png'></video>
 </body>
 </html>


### PR DESCRIPTION
```<video>``` element could have a ```poster``` attribute specifying the image displayed before the video starts playing. Currently, grunt-relative-root does not relativize poster urls. With this addition, it does.